### PR TITLE
Enable character files with "facial hair count" of 4 to be loaded

### DIFF
--- a/src/Chf/FacialHair.ts
+++ b/src/Chf/FacialHair.ts
@@ -87,7 +87,7 @@ export function readFacialHair(reader: BufferReader): FacialHair {
   switch (childCount) {
     case 0: {
       const count2 = reader.readUint32()
-      if (count2 !== 5 && count2 !== 6)
+      if (count2 !== 4 && count2 !== 5 && count2 !== 6)
         throw new Error('Unknown facial hair count')
 
       reader.expectUint32(5)


### PR DESCRIPTION
@diogotr7 For your consideration, this PR adds `4` as an allowed "facial hair count" and fixes #1.

After making this fix, I adjusted the character's skin color and exported the resulting character. The game appears to accept the modified character and displays the correct skin color in the character editor.